### PR TITLE
Fix typo in the base URL definition

### DIFF
--- a/earthhub/values.yaml
+++ b/earthhub/values.yaml
@@ -1,6 +1,6 @@
 jupyterhub:
   hub:
-    baseUrl: /earthhub
+    baseUrl: /earthhub/
   proxy:
     service:
       type: ClusterIP

--- a/staginghub/values.yaml
+++ b/staginghub/values.yaml
@@ -1,6 +1,6 @@
 jupyterhub:
   hub:
-    baseUrl: /staginghub
+    baseUrl: /staginghub/
   proxy:
     service:
       type: ClusterIP


### PR DESCRIPTION
The trailing `/` turns out to be important.

Change has been deployed.