### PR TITLE
Make it easier to run `deploy.py` locally

### DIFF
--- a/staginghub/values.yaml
+++ b/staginghub/values.yaml
@@ -22,4 +22,4 @@ jupyterhub:
     google:
       callbackUrl: "https://hub.earthdatascience.org/staginghub/hub/oauth_callback"
       hostedDomain: "colorado.edu"
-      loginService: "Colorado University1"
+      loginService: "Colorado University"


### PR DESCRIPTION
This adds a `--no-setup` flag to `deploy.py` so that you don't have to edit it if you want to run it locally. Running it by hand should be a rare occasion.

This also changes things so that we see more of the command's output for debugging purposes.