### PR TITLE
Update staginghub to latest JupyterHub chart

### DIFF
--- a/staginghub/requirements.yaml
+++ b/staginghub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7-e2757f0"
+  version: "v0.7-f8dec3f"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
With the current chart user pods seem to hang when being launched. Or at least the hub things they are hanging.