### PR TITLE
Remove user whitelist

### DIFF
--- a/wshub/values.yaml
+++ b/wshub/values.yaml
@@ -8,7 +8,6 @@ jupyterhub:
     extraConfig:
       auth: |
         c.JupyterHub.authenticator_class = 'hashauthenticator.HashAuthenticator'
-        c.Authenticator.whitelist = {'leah', 'leah-admin', 'tim-admin', 'tim'}
       admin: |
         c.Authenticator.admin_users = {'leah-admin', 'tim-admin'}
         c.JupyterHub.admin_access = True


### PR DESCRIPTION
https://github.com/thedataincubator/jupyterhub-hashauthenticator doesn't seem to honour the whitelist. Not a big deal as random users would need to know the secret key in order to know their password.