### PR TITLE
Increase start timeout for workshop hub to ten minutes

### DIFF
--- a/wshub/values.yaml
+++ b/wshub/values.yaml
@@ -20,6 +20,7 @@ jupyterhub:
       # tag will be set by travis on deployment
       name: earthlabhubops/ea-k8s-user-wshub
       tag: set-on-deployment
+    startTimeout: 600
     cpu:
       guarantee: 1.
       limit: 2.


### PR DESCRIPTION
Pulling the singleuser image + starting a new node takes around 5minutes which is exactly what the start timeout is. So for a large fraction of spawns that require a new node things fail because we run into this limit. Increasing the limit to 10m.

An additional thing to investigate is how to speed up pulling the image. How much does running our own docker registry on google cloud cost and does that have a faster network connection to the nodes?