### PR TITLE
Change data update behaviour to use rsync

### DIFF
--- a/user-images/wshub/Dockerfile
+++ b/user-images/wshub/Dockerfile
@@ -7,9 +7,16 @@ RUN pip install --no-cache git+https://github.com/data-8/nbgitpuller@28fe9b1af2b
 RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
 
 USER root
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+       rsync \
+    && apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Have to explicitly change the matplotlib backend in order to use
 # earthpy on the command line.
 RUN python -c "import matplotlib; matplotlib.use('Agg'); import earthpy; data = earthpy.io.EarthlabData('/data'); data.get_data('spatial-vector-lidar')"
-USER $NB_UID
 
-# a comment to trigger rebuilding
+USER $NB_UID

--- a/wshub/values.yaml
+++ b/wshub/values.yaml
@@ -34,10 +34,7 @@ jupyterhub:
             - "sh"
             - "-c"
             - >
-              if [ ! -d /home/jovyan/earth-analytics/data/spatial-vector-lidar ]; then
-              mkdir -p /home/jovyan/earth-analytics/data/;
-              cp -a /data/spatial-vector-lidar /home/jovyan/earth-analytics/data/;
-              fi;
+              rsync --ignore-existing -razv --progress /data/ /home/jovyan/earth-analytics/data
               gitpuller https://github.com/earthlab-education/2018-07-20-spatial-python-workshop master materials;
   proxy:
     service:


### PR DESCRIPTION
This uses rsync to update the data in a user's home directory. With this
we change the behaviour so that:
* if a user edited a data file it will not be overwritten
* if there are new data files in the "source" they will be copied over

What we do not support right now is a file in the source being modified
and then overwrite what the user has in their hme directory. For files
that already exist in the user's home directory that version always
wins. In order to get a new version a user has to explicitly delete the
file they want to update in their home directory, stop their server,
wait for it to stop, start the server again.