### PR TITLE
Make sure target directory exists before rsync'ing

### DIFF
--- a/wshub/values.yaml
+++ b/wshub/values.yaml
@@ -34,6 +34,7 @@ jupyterhub:
             - "sh"
             - "-c"
             - >
+              mkdir -p /home/jovyan/earth-analytics/data;
               rsync --ignore-existing -razv --progress /data/ /home/jovyan/earth-analytics/data;
               gitpuller https://github.com/earthlab-education/2018-07-20-spatial-python-workshop master notebooks;
   proxy:


### PR DESCRIPTION
🌺🌺🌺Hold off merging this until after the workshop is over!🌺🌺🌺

If the target directory doesn't exist rsync will fail. This meant several users at today's workshop didn't get the data in their home directory.