### PR TITLE
Update staging hub to a newer chart version

### DIFF
--- a/staginghub/requirements.yaml
+++ b/staginghub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7-f8dec3f"
+  version: "v0.7-560a7cd"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
The old staginghub chart has the problem where it can't create a new hub because of the pod disruption budget.