### PR TITLE
Resource limits

### DIFF
--- a/earthhub/values.yaml
+++ b/earthhub/values.yaml
@@ -5,6 +5,13 @@ jupyterhub:
       prometheus.io/scrape: "true"
       # this needs to start with the value of `hub.baseUrl`
       prometheus.io/path: /earthhub/hub/metrics
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
   singleuser:
     image:
       # tag will be set by travis on deployment
@@ -19,6 +26,13 @@ jupyterhub:
   proxy:
     service:
       type: ClusterIP
+    resources:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
   ingress:
     enabled: true
     hosts:

--- a/outer-edge/values.yaml
+++ b/outer-edge/values.yaml
@@ -1,4 +1,11 @@
 controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 1Gi
+    limits:
+      cpu: 0.5
+      memory: 1Gi
   service:
     loadBalancerIP: 35.226.96.84
   metrics:

--- a/staginghub/values.yaml
+++ b/staginghub/values.yaml
@@ -5,6 +5,13 @@ jupyterhub:
       prometheus.io/scrape: "true"
       # this needs to start with the value of `hub.baseUrl`
       prometheus.io/path: /staginghub/hub/metrics
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
   singleuser:
     image:
       # tag will be set by travis on deployment
@@ -20,6 +27,13 @@ jupyterhub:
   proxy:
     service:
       type: ClusterIP
+    resources:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
   ingress:
     enabled: true
     hosts:

--- a/wshub/values.yaml
+++ b/wshub/values.yaml
@@ -5,6 +5,13 @@ jupyterhub:
       prometheus.io/scrape: "true"
       # this needs to start with the value of `hub.baseUrl`
       prometheus.io/path: /wshub/hub/metrics
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     extraConfig:
       auth: |
         c.JupyterHub.authenticator_class = 'hashauthenticator.HashAuthenticator'
@@ -40,6 +47,13 @@ jupyterhub:
   proxy:
     service:
       type: ClusterIP
+    resources:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
This sets resource limits and requests for the various components we have.

By being good at setting limits we can size the part of the cluster that has to be "always on" as small as possible. If we set the limit too low we bump into it, if we set it too high the cluster will be mostly empty. I expect we will have to keep tweaking these for a bit. [Goals](https://makeagif.com/i/wrIfII)