### PR TITLE
User whitelist

### DIFF
--- a/staginghub/values.yaml
+++ b/staginghub/values.yaml
@@ -49,6 +49,8 @@ jupyterhub:
 
   auth:
     type: google
+    whitelist:
+      users: tihe1369
     google:
       callbackUrl: "https://hub.earthdatascience.org/staginghub/hub/oauth_callback"
       hostedDomain: "colorado.edu"


### PR DESCRIPTION
Answers #80 

User whitelist should be independent of the authentication mechanism.