### PR TITLE
Add Dockerfile for the custom bootcamp-hub deployment

### DIFF
--- a/user-images/bootcamp-hub/Dockerfile
+++ b/user-images/bootcamp-hub/Dockerfile
@@ -1,0 +1,8 @@
+FROM earthlab/earth-analytics-python-env:41ae80f
+
+RUN pip install --no-cache --upgrade --upgrade-strategy only-if-needed \
+  jupyterhub==0.9.0 nbzip==0.0.4
+
+RUN jupyter serverextension enable --py nbzip --sys-prefix
+RUN jupyter nbextension install --py nbzip --sys-prefix
+RUN jupyter nbextension enable --py nbzip --sys-prefix


### PR DESCRIPTION
Adds the missing `Dockerfile` to build a custom docker image for the bootcamp-hub.