### PR TITLE
Add forced cluster scaling snippets

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -24,5 +24,5 @@ To remove the big pods: `kubectl delete deployment cluster-scale-deployment --na
 after the class/workshop/event is over as they consume nearly no resources.
 After the envet is over you want to delete them again to allow the cluster to
 shrink again, use: `kubectl delete deployment cluster-pin-deployment --namespace=bootcamp-hub`
-to do so. After about 10-15minutes nodes that are not needed anymore should
+to do so. After about 30minutes nodes that are not needed anymore should
 start being removed.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,28 @@
+# Assorted tools
+
+A collection of various tools that have no other place to go.
+
+## Forced cluster scaling
+
+To force the cluster to scale up use `scale-cluster.yaml`. It
+will schedule two big pods that will lead to two new nodes being
+provisioned. To start the process run `kubectl create -f scale-cluster.yaml`
+from this directory. These pods will request 5 units of CPU which
+is more than half the amount of CPU each node provides.
+
+Use `kubectl get pods --namespace bootcamp-hub` to check your additional pods
+have been scheduled and are running. These pods request a lot of CPU in order
+to trigger the scaling up, but they don't do anything with it, and while they
+have requested it no one else can use it either.
+
+The next step is to run `kubectl create -f pin-cluster.yaml` which will start
+the same number of pods requesting nearly no CPU. Once these are up and running
+we can remove the big pods again as the autoscaler will not remove a virtual
+machine that has pods running on it.
+
+To remove the big pods: `kubectl delete deployment cluster-scale-deployment --namespace=bootcamp-hub`. You can safely leave the small pods running until
+after the class/workshop/event is over as they consume nearly no resources.
+After the envet is over you want to delete them again to allow the cluster to
+shrink again, use: `kubectl delete deployment cluster-pin-deployment --namespace=bootcamp-hub`
+to do so. After about 10-15minutes nodes that are not needed anymore should
+start being removed.

--- a/tools/pin-cluster.yaml
+++ b/tools/pin-cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-pin-deployment
+  namespace: bootcamp-hub
+  labels:
+    app: cluster-pin
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cluster-pin
+  template:
+    metadata:
+      labels:
+        app: cluster-pin
+    spec:
+      nodeSelector:
+        earthlab.org/pool-type: user
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cluster-pin
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: cluster-pin
+        image: earthlabhubops/ea-k8s-user-bootcamp-hub:fb2482f
+        resources:
+          limits:
+            cpu: "1m"
+          requests:
+            cpu: "1m"

--- a/tools/scale-cluster.yaml
+++ b/tools/scale-cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-scale-deployment
+  namespace: bootcamp-hub
+  labels:
+    app: cluster-scaler
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cluster-scaler
+  template:
+    metadata:
+      labels:
+        app: cluster-scaler
+    spec:
+      nodeSelector:
+        earthlab.org/pool-type: user
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cluster-scaler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: cluster-scaler
+        image: earthlabhubops/ea-k8s-user-bootcamp-hub:fb2482f
+        resources:
+          limits:
+            cpu: "5"
+          requests:
+            cpu: "5"


### PR DESCRIPTION
These two snippets allow us to force the cluster to scale up and then stop it from scaling down again. This is useful to provision some spare capacity ahead of a workshop/class starting.

It requires manual supervision and undoing once you do not need it any more as the provisioned virtual machines/nodes will not be removed again until you say so. This means they will keep costing you money if you forget to turn this off again.

cc @lwasser 