### PR TITLE
Use infinite clone depth on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: python
 python:
 - 3.6
 
+# checkout all of the history, not just last 50 commits
+# needed to help us work out the correct docker tags for
+# things that haven't changed in a long time
+git:
+  depth: false
+
 services:
 - docker
 


### PR DESCRIPTION
What might be happening is that we don't checkout enough of the history to work out what the correct tag is to use for the image. Which causes https://travis-ci.org/earthlab/hub-ops/builds/413659311?utm_source=github_status&utm_medium=notification to fail because it determines a too recent commit as the tag to use.

Travis docs: https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth