### PR TITLE
Update bootcamphub to newer jupyterhub version

### DIFF
--- a/bootcamp-hub/requirements.yaml
+++ b/bootcamp-hub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7-560a7cd"
+  version: "v0.7-d5a68a3"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/user-images/bootcamp-hub/Dockerfile
+++ b/user-images/bootcamp-hub/Dockerfile
@@ -1,7 +1,7 @@
 FROM earthlab/earth-analytics-python-env:41ae80f
 
 RUN pip install --no-cache --upgrade --upgrade-strategy only-if-needed \
-  jupyterhub==0.9.0 nbzip==0.0.4 git+https://github.com/data-8/nbgitpuller@28fe9b1af2ba64b346d59bd13c99581346bf349f
+  jupyterhub==0.9.2 nbzip==0.1.0 git+https://github.com/data-8/nbgitpuller@28fe9b1af2ba64b346d59bd13c99581346bf349f
 
 RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
 RUN jupyter serverextension enable --py nbzip --sys-prefix


### PR DESCRIPTION
This brings the bootcamp hub to JupyterHub v0.9.2. The main benefit of this update is that the newer JupyterHub can restart itself if too many consecutive spawns failed. This is a bandaid for the real problem that sometimes the JupyterHub spawner loses track of what pods are starting/running/finished. It manifests itself in a user logging in to the hub, their pod starts up but JupyterHub never notices and keeps the user waiting for ever. The "fix" for this behaviour is to restart the hub manually. With the latest version of jupyterhub the hub restarts itself if there are five consecutive launch failures.