### PR TITLE
Fix certificate renewal process

### DIFF
--- a/outer-edge/README.md
+++ b/outer-edge/README.md
@@ -40,6 +40,11 @@ and installed kube-lego v0.4.2 via
 helm install --name lego --namespace router stable/kube-lego --set rbac.create=true --set config.LEGO_EMAIL=Leah.Wasser@colorado.edu --set config.LEGO_URL=https://acme-v01.api.letsencrypt.org/directory
 ```
 
+To update or change the configuration of kube-lego use:
+```
+helm upgrade --namespace router lego stable/kube-lego -f outer-edge/values.yaml --set rbac.create=true
+```
+
 Set IP address by hand, unsure why I needed this:
 ```
 kubectl patch svc --namespace router ingress-nginx-ingress-controller -p '{"spec": {"loadBalancerIP": "35.226.96.84"}}'

--- a/outer-edge/values.yaml
+++ b/outer-edge/values.yaml
@@ -19,3 +19,9 @@ controller:
 config:
   LEGO_EMAIL: Leah.Wasser@colorado.edu
   LEGO_URL: https://acme-v01.api.letsencrypt.org/directory
+# the below is needed to set the right version of kube-lego
+# as 0.1.6 (the default for the chart) doesn't actually renew certificates
+# This commented out by default so that it doesn't interfer with nginx-ingress
+# configuration
+#image:
+#  tag: 0.1.7


### PR DESCRIPTION
Update our version of kube-lego to fix #133 

Now certificates should get renewed in time.