### PR TITLE
Run pip install of notebook in separate command

### DIFF
--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -3,8 +3,9 @@ FROM earthlab/earth-analytics-python-env:8b22287
 RUN pip install --no-cache --upgrade --upgrade-strategy only-if-needed \
   jupyterhub==0.9.2 \
   nbzip==0.1.0 \
-  https://github.com/data-8/nbgitpuller/archive/28fe9b1af2ba64b346d59bd13c99581346bf349f.zip \
-  https://github.com/jupyter/notebook/archive/9d19aa3677a414341c5368622b01a2d229c2bad1.zip
+  https://github.com/data-8/nbgitpuller/archive/28fe9b1af2ba64b346d59bd13c99581346bf349f.zip
+
+RUN pip install --no-cache --upgrade https://github.com/jupyter/notebook/archive/9d19aa3677a414341c5368622b01a2d229c2bad1.zip
 
 
 RUN jupyter serverextension enable --py nbgitpuller --sys-prefix


### PR DESCRIPTION
Second attempt, in #142 pip decided that the notebook was already installed and there was no need to upgrade it.