### PR TITLE
Remove bootcamp hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ script:
   # Build earthhub
   python ./deploy.py --no-setup --build ea-hub
 - |
-  # Build bootcamp-hub
-  python ./deploy.py --no-setup --build bootcamp-hub
-- |
   # Build nbgrader-hub
   python ./deploy.py --no-setup --build nbgrader-hub
 - |
@@ -75,9 +72,6 @@ before_deploy:
 - |
   # Stage 3, Step 2: Deploy the earthhub
   python ./deploy.py --build --push --deploy ea-hub
-- |
-  # Stage 3, Step 3: Deploy the bootcamp-hub
-  python ./deploy.py --build --push --deploy bootcamp-hub
 - |
   # Stage 3, Step 4: Deploy the nbgrader-hub
   python ./deploy.py --build --push --deploy nbgrader-hub

--- a/deploy.py
+++ b/deploy.py
@@ -267,7 +267,7 @@ def main():
     argparser.add_argument(
         'chartname',
         help="Select which chart to deploy",
-        choices=['staginghub', 'ea-hub', 'wshub', 'bootcamp-hub', 'nbgrader-hub', 'monitoring']
+        choices=['staginghub', 'ea-hub', 'nbgrader-hub', 'monitoring']
     )
 
     args = argparser.parse_args()

--- a/docs/source/day-to-day.rst
+++ b/docs/source/day-to-day.rst
@@ -333,7 +333,7 @@ similar to this::
 Depending on how many hubs are running there will be at least three releases
 deployed: :code:`ingress`, :code:`lego`, and :code:`monitoring`. These support
 all hubs and should never be removed. In the case shown above there are three
-hubs running: :code:`staginghub`, :code:`wshub` and :code:earthhub`.
+hubs running: :code:`staginghub`, :code:`wshub` and :code:`earthhub`.
 
 To delete the :code:`wshub` run :code:`helm delete wshub --purge`. If you now
 visit :code:`https://hub.earthdatascience.org/<hubname>/` you should get a 404 error.

--- a/docs/source/day-to-day.rst
+++ b/docs/source/day-to-day.rst
@@ -271,7 +271,8 @@ The first step in removing a hub is to turn it off. To do this
 1. Open the  :code:`travis.yml` file in the root of the hub-ops repo.
 2. Remove the commands listed below
 
-In the :code:`scripts` section remove:
+For example, to remove a hub called `bootcamp-hun`, in the :code:`scripts`
+section remove:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This hub is from a course in July 2018 and no longer needed. PR does not delete the information about the hub, simply removes the build from travis. 