### PR TITLE
remove nbgrader-hub from deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ script:
   # Build earthhub
   python ./deploy.py --no-setup --build ea-hub
 - |
-  # Build nbgrader-hub
-  python ./deploy.py --no-setup --build nbgrader-hub
-- |
   # Build documentation
   pushd docs && make html && popd
 
@@ -72,9 +69,6 @@ before_deploy:
 - |
   # Stage 3, Step 2: Deploy the earthhub
   python ./deploy.py --build --push --deploy ea-hub
-- |
-  # Stage 3, Step 4: Deploy the nbgrader-hub
-  python ./deploy.py --build --push --deploy nbgrader-hub
 - |
   # Stage 3, Step 5: Deploy monitoring of the hubs
   python ./deploy.py --deploy monitoring


### PR DESCRIPTION
Deleting commands that deploy changes to the nbgrader-hub, which is step 1 of [instructions for removing a hub](https://earthlab-hub-ops.readthedocs.io/en/latest/day-to-day.html#step-one-turn-off-your-hub-autobuild-update)