### PR TITLE
Add nbgitpuller back to the hub

### DIFF
--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -30,6 +30,14 @@ jupyterhub:
     memory:
       guarantee: 2G
       limit: 4G
+    lifecycleHooks:
+      postStart:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - >
+              gitpuller https://github.com/earthlab-education/earth-analytics-fall-2018 master homework-templates;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool

--- a/user-images/README.md
+++ b/user-images/README.md
@@ -1,7 +1,7 @@
 # Docker images used to customise the user's environment
 
 This folder contains the `Dockerfile`s needed to build the image in which a
-user runs. Use this if you want to make specific Python libraries available
+user runs. Use this if you want to make specific `Python` libraries available
 to your users or install additional kernels.
 
 Each hub has its own image.
@@ -9,12 +9,13 @@ Each hub has its own image.
 If you want to customize the environment that the hub itself runs in `hub-images/`
 instead.
 
-`earthenv-user` is an image that contains the Earthlab Analytics Python
-environment. The source of which is mainted here: https://github.com/earthlab/earth-analytics-python-env
+`earthenv-user` is an image that contains the Earth Analytics Python
+environment. The source of this conda environment  is maintained here:
+https://github.com/earthlab/earth-analytics-python-env
 
 
 ## Automated builds
 
-Unfortuantely we can not use Docker Hub for building these as we need them to
+Unfortunately we can not use Docker Hub for building these as we need them to
 be ready when we deploy the hub(s) that use them. Instead we build them on
 travis and then push to Docker Hub. The tooling is in `deploy.py`

--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -17,9 +17,8 @@ RUN jupyter nbextension disable --sys-prefix create_assignment/main \
 # disable formgrader
     && jupyter nbextension disable --sys-prefix formgrader/main --section=tree \
     && jupyter serverextension disable --sys-prefix \
-  nbgrader.server_extensions.formgrader
-
+  nbgrader.server_extensions.formgrader \
 # disable assignment_list
-RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree \
+    && jupyter nbextension disable --sys-prefix assignment_list/main --section=tree \
     && jupyter serverextension disable --sys-prefix \
   nbgrader.server_extensions.assignment_list

--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -5,22 +5,21 @@ FROM earthlab/earth-analytics-python-env:ed6ee91
 # them all and then disable the ones you don't want. Hmmm, ok.
 
 # setup nbgitpuller to sync files
-RUN conda install -c conda-forge nbgitpuller
-RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
+RUN conda install -c conda-forge nbgitpuller \
+    && jupyter serverextension enable --py nbgitpuller --sys-prefix
 
-RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite
-RUN jupyter nbextension enable --sys-prefix --py nbgrader
-RUN jupyter serverextension enable --sys-prefix --py nbgrader
+RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite \
+    && jupyter nbextension enable --sys-prefix --py nbgrader \
+    && jupyter serverextension enable --sys-prefix --py nbgrader
 
-# disable create_assignment
-RUN jupyter nbextension disable --sys-prefix create_assignment/main
-
+# disable create_assignment & formgrader
+RUN jupyter nbextension disable --sys-prefix create_assignment/main \
 # disable formgrader
-RUN jupyter nbextension disable --sys-prefix formgrader/main --section=tree
-RUN jupyter serverextension disable --sys-prefix \
+    && jupyter nbextension disable --sys-prefix formgrader/main --section=tree \
+    && jupyter serverextension disable --sys-prefix \
   nbgrader.server_extensions.formgrader
 
 # disable assignment_list
-RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree
-RUN jupyter serverextension disable --sys-prefix \
+RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree \
+    && jupyter serverextension disable --sys-prefix \
   nbgrader.server_extensions.assignment_list

--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -4,6 +4,8 @@ FROM earthlab/earth-analytics-python-env:ed6ee91
 # validate extension, but you can't just install one. You need to install
 # them all and then disable the ones you don't want. Hmmm, ok.
 
+RUN conda install -c conda-forge nbgitpuller
+
 RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite
 RUN jupyter nbextension enable --sys-prefix --py nbgrader
 RUN jupyter serverextension enable --sys-prefix --py nbgrader

--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -4,7 +4,9 @@ FROM earthlab/earth-analytics-python-env:ed6ee91
 # validate extension, but you can't just install one. You need to install
 # them all and then disable the ones you don't want. Hmmm, ok.
 
+# setup nbgitpuller to sync files
 RUN conda install -c conda-forge nbgitpuller
+RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
 
 RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite
 RUN jupyter nbextension enable --sys-prefix --py nbgrader


### PR DESCRIPTION
I think this should in theory add [nbgitpuller](https://jupyterhub.github.io/nbgitpuller/install.html#install) back 

- [x] @jlpalomino notice i am calling an OLD repo that i used for class last year  - https://github.com/earthlab-education/earth-analytics-fall-2018 i suggest that you create a new repo for the bootcamp and we can edit this accordingly. when you've created that repo, please add the name / link  in a comment below and i'll update here. 
- [ ] i *think* conda install will work here but i'm not 100% sure!! it should based upon our ea envt but i don't know if that is installed on TOP of this so that it may not be available or is it? @kcranston let me know if this looks weird
- [ ] i've pinged twitter about combining RUN statements. not expecting much on a holiday weekend on a friday but thought i'd try!

i really like using nbgitpuller in the hub and don't want to remove it unless we think using good old git is equally useful. it is a very nice tool and worked well as it just always synced things automagically.

this also tries to remove layers by merging run statements