### PR TITLE
Update homework template repo for EA Bootcamp in ea-hub/values.yaml

### DIFF
--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -37,7 +37,7 @@ jupyterhub:
             - "sh"
             - "-c"
             - >
-              gitpuller https://github.com/earthlab-education/earth-analytics-fall-2018 master homework-templates;
+              gitpuller https://github.com/earthlab-education/earth-analytics-bootcamp-fall-2019 master ea-homework-notebooks;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool


### PR DESCRIPTION
@lwasser This PR updates the repository and directory name for the homework template. The repository is a public repository created to get the homework templates onto the hub.  Fixes #175 