### PR TITLE
Update staginghub to match ea-hub

### DIFF
--- a/hub-charts/staginghub/requirements.yaml
+++ b/hub-charts/staginghub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7-560a7cd"
+  version: "v0.8.2"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/hub-charts/staginghub/values.yaml
+++ b/hub-charts/staginghub/values.yaml
@@ -26,6 +26,14 @@ jupyterhub:
     memory:
       guarantee: 500M
       limit: 500M
+    lifecycleHooks:
+      postStart:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - >
+              gitpuller https://github.com/earthlab-education/earth-analytics-bootcamp-fall-2019 master ea-homework-notebooks;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool
@@ -44,7 +52,7 @@ jupyterhub:
     hosts:
       - hub.earthdatascience.org
     annotations:
-      ingress.kubernetes.io/proxy-body-size: 64m
+      nginx.ingress.kubernetes.io/proxy-body-size: 64m
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
     tls:
@@ -53,8 +61,18 @@ jupyterhub:
           - hub.earthdatascience.org
 
   auth:
-    type: google
-    google:
+    admin:
+      access: true
+      users:
+        - kcranston
+        - lwasser
+        - jlpalomino
+    whitelist:
+      users:
+        - kcranston
+        - lwasser
+        - jlpalomino
+        - eastudent
+    type: github
+    github:
       callbackUrl: "https://hub.earthdatascience.org/staginghub/hub/oauth_callback"
-      hostedDomain: "colorado.edu"
-      loginService: "Colorado University"

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -1,4 +1,4 @@
-FROM earthlab/earth-analytics-python-env:ed6ee91
+FROM earthlab/earth-analytics-python-env
 
 # Install nbgrader server extensions - we only want the students to see the
 # validate extension, but you can't just install one. You need to install

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -1,8 +1,24 @@
-FROM earthlab/earth-analytics-python-env:41ae80f
+FROM earthlab/earth-analytics-python-env:ed6ee91
 
-RUN pip install --no-cache --upgrade --upgrade-strategy only-if-needed \
-  jupyterhub==0.9.0 nbzip==0.0.4
+# Install nbgrader server extensions - we only want the students to see the
+# validate extension, but you can't just install one. You need to install
+# them all and then disable the ones you don't want. Hmmm, ok.
 
-RUN jupyter serverextension enable --py nbzip --sys-prefix
-RUN jupyter nbextension install --py nbzip --sys-prefix
-RUN jupyter nbextension enable --py nbzip --sys-prefix
+# setup nbgitpuller to sync files
+RUN conda install -c conda-forge nbgitpuller \
+    && jupyter serverextension enable --py nbgitpuller --sys-prefix
+
+RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite \
+    && jupyter nbextension enable --sys-prefix --py nbgrader \
+    && jupyter serverextension enable --sys-prefix --py nbgrader
+
+# disable create_assignment & formgrader
+RUN jupyter nbextension disable --sys-prefix create_assignment/main \
+# disable formgrader
+    && jupyter nbextension disable --sys-prefix formgrader/main --section=tree \
+    && jupyter serverextension disable --sys-prefix \
+  nbgrader.server_extensions.formgrader \
+# disable assignment_list
+    && jupyter nbextension disable --sys-prefix assignment_list/main --section=tree \
+    && jupyter serverextension disable --sys-prefix \
+  nbgrader.server_extensions.assignment_list


### PR DESCRIPTION
This updates the hub-charts and user-images in staginghub to be the same as ea-hub. Then, we can use staginghub as a first step of deploying changes, check that everything is working, and then update ea-hub to match. 