### PR TITLE
Update EA Python students in ea-hub/values.yaml

### DIFF
--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -81,7 +81,6 @@ jupyterhub:
         - wpaigej
         - calekochenour
         - coro1253
-        - kbfeldmann
         - kessb
         - chbr1191
         - shaheen19
@@ -91,21 +90,15 @@ jupyterhub:
         - calerwilliams
         - stephlshep
         - richardudell
-        - cantord1698
         - ReedtheRiver
         - ClaireKarban
         - nickaplan
         - wolterso
-        - isabelschroeter
         - evangallagher
         - timd409
-        - jweber333
-        - jaeyoungjin
-        - kezi7216
         - annapav7
         - toastferry
         - sauer3
-        - 4ryanwhite
         - nkorinek
     type: github
     github:

--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -95,7 +95,6 @@ jupyterhub:
         - nickaplan
         - wolterso
         - evangallagher
-        - timd409
         - annapav7
         - toastferry
         - sauer3


### PR DESCRIPTION
@lwasser @kcranston This PR updates the GitHub usernames for the EA Python course.
- [X] Remove undergrads and non-completions from Bootcamp course
- [x] Remove grads and certificate students that are not taking EA Python

After Wed 1/22 (last of registration), there may be a few more names that will be removed, but this is a good start to the clean up.