### PR TITLE
Remove students not in EA Python course

### DIFF
--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -89,17 +89,13 @@ jupyterhub:
         - sarahmjaffe
         - dphillips97
         - krosenberg01
-        - calerwilliams
         - stephlshep
         - richardudell
-        - ReedtheRiver
         - ClaireKarban
         - nickaplan
         - wolterso
         - evangallagher
         - annapav7
-        - toastferry
-        - sauer3
         - nkorinek
     type: github
     github:


### PR DESCRIPTION
@lwasser This PR removes students who are not actively enrolled in the EA Python course at this time (toastferry will receive an incomplete for this course at the end of the semester). 