### PR TITLE
Update version of jupyter hub helm chart on staginghub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ install:
   # pip install -U pyyaml pytest requests sphinx sphinx-autobuild
   pip install -r dev-requirements.txt
 script:
-#- |
+- |
   # Build staginghub
-  #python ./deploy.py --no-setup --build staginghub
+  python ./deploy.py --no-setup --build staginghub
 - |
   # Build earth-analytics-hub
   python ./deploy.py --no-setup --build ea-hub

--- a/hub-charts/staginghub/requirements.yaml
+++ b/hub-charts/staginghub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.8.2"
+  version: "v0.9.0"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/hub-charts/staginghub/values.yaml
+++ b/hub-charts/staginghub/values.yaml
@@ -33,7 +33,7 @@ jupyterhub:
             - "sh"
             - "-c"
             - >
-              gitpuller https://github.com/earthlab-education/earth-analytics-bootcamp-fall-2019 master ea-homework-notebooks;
+              gitpuller https://github.com/earthlab-education/spring-2020-course-notebooks master ea-2020-class-notebooks;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -1,13 +1,17 @@
-FROM earthlab/earth-analytics-python-env:2869054
+FROM earthlab/earth-analytics-python-env:84549e0
 
 # Install nbgrader server extensions - we only want the students to see the
 # validate extension, but you can't just install one. You need to install
 # them all and then disable the ones you don't want. Hmmm, ok.
 
-# setup nbgitpuller to sync files
+# Setup nbgitpuller to sync files from course repo to hub
 RUN conda install -c conda-forge nbgitpuller \
     && jupyter serverextension enable --py nbgitpuller --sys-prefix
 
+# Setup nbzip - this allows students to download files from the hub
+RUN pip install git+https://github.com/ryanlovett/jupyter-tree-download.git
+
+# Setup nbgrader + extensions
 RUN jupyter nbextension install --sys-prefix --py nbgrader --overwrite \
     && jupyter nbextension enable --sys-prefix --py nbgrader \
     && jupyter serverextension enable --sys-prefix --py nbgrader


### PR DESCRIPTION
Updating the jupyterhub helm chart for the staging hub. The latest version includes [this commit](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/61cf357992f605a6a0e18e7dd27d404f34ec5315) which addresses the warning we are seeing in travis. I have no idea if this will fix things, but this PR does not affect ea-hub, so it seems safe. 