### PR TITLE
Separate build & push from deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ install:
   pip install -r dev-requirements.txt
 script:
 - |
-  # Build staginghub
+  # Build staginghub image
   python ./deploy.py --no-setup --build staginghub
 - |
-  # Build earth-analytics-hub
+  # Build earth-analytics-hub image
   python ./deploy.py --no-setup --build ea-hub
 - |
-  # Build edsc-hub
+  # Build edsc-hub image
   python ./deploy.py --no-setup --build edsc-hub
 - |
   # Build documentation
@@ -36,6 +36,7 @@ script:
 # We are using before_deploy instead of script or deploy
 # since before_deploy gives us nice, folded log views,
 # which neither script nor deploy seems to!
+# Tasks here only run after merge
 before_deploy:
 - |
   # Stage 1: Install gcloud SDK
@@ -68,16 +69,19 @@ before_deploy:
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
   helm repo update
 - |
-  # Stage 3a, Step 1: Deploy the staginghub
-  python ./deploy.py --build --push --deploy staginghub
+  # Stage 3, Step 1: Build & push image, then deploy staginghub
+  python ./deploy.py --build --push staginghub
+  python ./deploy.py --deploy staginghub
 - |
-  # Stage 3b, Step 2: Deploy the edsc-hub
-  python ./deploy.py --build --push --deploy edsc-hub
+  # Stage 3, Step 2: Build & push image, then deploy edsc-hub
+  python ./deploy.py --build --push edsc-hub
+  python ./deploy.py --deploy edsc-hub
 - |
-  # Stage 3c, Step 2: Deploy the earth-analytics-hub
-  python ./deploy.py --build --push --deploy ea-hub
+  # Stage 3, Step 2: Build & push image, then deploy earth-analytics-hub
+  python ./deploy.py --build --push ea-hub
+  python ./deploy.py --deploy ea-hub
 - |
-  # Stage 3d, Step 5: Deploy monitoring of the hubs
+  # Stage 3, Step 4: Deploy monitoring of the hubs
   python ./deploy.py --deploy monitoring
 
 

--- a/deploy.py
+++ b/deploy.py
@@ -83,7 +83,7 @@ def get_next_image_spec(chartname, image_dir):
         image_name = "earthlabhubops/ea-k8s-user-" + chartname
         image_spec = image_name + ':' + tag
         return image_spec
-    else
+    else:
         return None
 
 def get_previous_image_spec(image_name, image_dir):

--- a/deploy.py
+++ b/deploy.py
@@ -153,11 +153,11 @@ def image_requires_build(image_dir, commit_range=None):
 #     return image_spec
 
 
-def build_user_image(hubname, commit_range, push=False):
+def build_user_image(chartname, commit_range, push=False):
     # Build and push to Docker Hub singleuser images that need updating
     # from `user-images/`
-    image_dir = "user-images/" + hubname
-    image_spec = get_next_image_spec(hubname, image_dir)
+    image_dir = "user-images/" + chartname
+    image_spec = get_next_image_spec(chartname, image_dir)
     if image_spec is None:
         return
 
@@ -197,7 +197,7 @@ def deploy(chartname):
 
     # Check for a custom singleuser image
     image_dir = "user-images/" + chartname
-    image_spec = get_next_image_spec(hubname, image_dir)
+    image_spec = get_next_image_spec(chartname, image_dir)
     if image_spec is not None:
         print("Using", image_spec, "as user image for", chartname)
         extra_args.extend(['--set-string',

--- a/deploy.py
+++ b/deploy.py
@@ -105,42 +105,42 @@ def image_requires_build(image_dir, commit_range=None):
     return image_touched
 
 
-def build_hub_image(hubname, commit_range, push=False):
-    # Build and push to Docker Hub the hub(!) images that need updating
-    # from `hub-images/`
-    image_dir = "hub-images/" + hubname
-    # No work for us if there is no custom user image
-    if not os.path.exists(image_dir):
-        return
-
-    tag = last_git_modified(image_dir)
-    image_name = "earthlabhubops/ea-k8s-hub-" + hubname
-    image_spec = image_name + ':' + tag
-
-    needs_rebuilding = image_requires_build(image_dir, commit_range)
-
-    if needs_rebuilding:
-        previous_image_spec = get_previous_image_spec(image_name, image_dir)
-
-        if previous_image_spec is not None:
-            docker('build',
-                   '--cache-from', previous_image_spec,
-                   '-t', image_spec,
-                   image_dir)
-        else:
-            docker('build',
-                   '-t', image_spec,
-                   image_dir)
-
-        if push:
-            docker('push', image_spec)
-
-        print('build completed for hub image', image_spec)
-
-    else:
-        print('Do not need to rebuild hub image, using', image_spec)
-
-    return image_spec
+# def build_hub_image(hubname, commit_range, push=False):
+#     # Build and push to Docker Hub the hub(!) images that need updating
+#     # from `hub-images/`
+#     image_dir = "hub-images/" + hubname
+#     # No work for us if there is no custom user image
+#     if not os.path.exists(image_dir):
+#         return
+#
+#     tag = last_git_modified(image_dir)
+#     image_name = "earthlabhubops/ea-k8s-hub-" + hubname
+#     image_spec = image_name + ':' + tag
+#
+#     needs_rebuilding = image_requires_build(image_dir, commit_range)
+#
+#     if needs_rebuilding:
+#         previous_image_spec = get_previous_image_spec(image_name, image_dir)
+#
+#         if previous_image_spec is not None:
+#             docker('build',
+#                    '--cache-from', previous_image_spec,
+#                    '-t', image_spec,
+#                    image_dir)
+#         else:
+#             docker('build',
+#                    '-t', image_spec,
+#                    image_dir)
+#
+#         if push:
+#             docker('push', image_spec)
+#
+#         print('build completed for hub image', image_spec)
+#
+#     else:
+#         print('Do not need to rebuild hub image, using', image_spec)
+#
+#     return image_spec
 
 
 def build_user_image(hubname, commit_range, push=False):
@@ -201,16 +201,18 @@ def deploy(chartname):
         extra_args.extend(['--set-string',
                            'jupyterhub.singleuser.image.tag={}'.format(tag)])
 
+    # No longer have hub-image dir, but leaving this here in case
+    # it gets resurrected in the future
     # Check for a custom hub image
-    hub_image_dir = "hub-images/" + chartname
-    if os.path.exists(hub_image_dir):
-        tag = last_git_modified(hub_image_dir)
-        image_name = "earthlabhubops/ea-k8s-hub-" + chartname
-        image_spec = image_name + ':' + tag
-
-        print("Using", image_spec, "as hub image for", chartname)
-        extra_args.extend(['--set-string',
-                           'jupyterhub.hub.image.tag={}'.format(tag)])
+    # hub_image_dir = "hub-images/" + chartname
+    # if os.path.exists(hub_image_dir):
+    #     tag = last_git_modified(hub_image_dir)
+    #     image_name = "earthlabhubops/ea-k8s-hub-" + chartname
+    #     image_spec = image_name + ':' + tag
+    #
+    #     print("Using", image_spec, "as hub image for", chartname)
+    #     extra_args.extend(['--set-string',
+    #                        'jupyterhub.hub.image.tag={}'.format(tag)])
 
     helm('dep', 'up', cwd=chart_dir)
 
@@ -281,7 +283,7 @@ def main():
     if args.build:
         commit_range = os.getenv('TRAVIS_COMMIT_RANGE')
         build_user_image(args.chartname, commit_range, push=args.push)
-        build_hub_image(args.chartname, commit_range, push=args.push)
+        # build_hub_image(args.chartname, commit_range, push=args.push)
 
     if args.deploy:
         deploy(args.chartname)

--- a/deploy.py
+++ b/deploy.py
@@ -86,8 +86,9 @@ def get_next_image_spec(chartname, image_dir):
     else:
         return None
 
-def get_previous_image_spec(image_name, image_dir):
+def get_previous_image_spec(chartname, image_dir):
     """Pull latest available version of image to maximize cache use."""
+    image_name = "earthlabhubops/ea-k8s-user-" + chartname
     try_count = 0
     # try increasingly older git revisions
     while try_count < 5:
@@ -164,7 +165,7 @@ def build_user_image(chartname, commit_range, push=False):
     needs_rebuilding = image_requires_build(image_dir, commit_range)
 
     if needs_rebuilding:
-        previous_image_spec = get_previous_image_spec(image_name, image_dir)
+        previous_image_spec = get_previous_image_spec(chartname, image_dir)
 
         if previous_image_spec is not None:
             docker('build',

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -7,7 +7,6 @@ FROM earthlab/earth-analytics-python-env:b997eb0
 # Setup nbgitpuller to sync files from course repo to hub
 RUN conda install -c conda-forge nbgitpuller \
     && jupyter serverextension enable --py nbgitpuller --sys-prefix
-ADD ../../wrap_gitpuller.py
 
 # Setup nbzip - this allows students to download files from the hub
 RUN pip install git+https://github.com/ryanlovett/jupyter-tree-download.git

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -1,4 +1,4 @@
-FROM earthlab/earth-analytics-python-env:84549e0
+FROM earthlab/earth-analytics-python-env:b997eb0
 
 # Install nbgrader server extensions - we only want the students to see the
 # validate extension, but you can't just install one. You need to install
@@ -7,6 +7,7 @@ FROM earthlab/earth-analytics-python-env:84549e0
 # Setup nbgitpuller to sync files from course repo to hub
 RUN conda install -c conda-forge nbgitpuller \
     && jupyter serverextension enable --py nbgitpuller --sys-prefix
+ADD ../../wrap_gitpuller.py
 
 # Setup nbzip - this allows students to download files from the hub
 RUN pip install git+https://github.com/ryanlovett/jupyter-tree-download.git


### PR DESCRIPTION
As discussed in #223, separate the build & push steps from the deploy steps so that these run as different python processes. Should make it easier to see when things fail / timeout. 

Also removed the references to building hub-images, as that whole directory got removed with PR #221 