### PR TITLE
update the ea envt to the most recent docker build

### DIFF
--- a/user-images/edsc-hub/Dockerfile
+++ b/user-images/edsc-hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM earthlab/earth-analytics-python-env:84549e0
+FROM earthlab/earth-analytics-python-env:f880467
 
 # Install nbgrader server extensions - we only want the students to see the
 # validate extension, but you can't just install one. You need to install


### PR DESCRIPTION
some weird things are happening in the build now.

## It's trying to pull an image that doesn't exist. 

It seems like it's trying to pull an image that doesnt exist? or there are several tags and i'm not sure why there are several tags that it's trying. 
https://travis-ci.org/github/earthlab/hub-ops/jobs/701861190#L284 

when i go to docker that build is clearly not there so i'm not sure why it's trying to pull it. 
<img width="710" alt="Screen Shot 2020-06-24 at 6 57 52 PM" src="https://user-images.githubusercontent.com/7649194/85641703-a29a1c80-b64c-11ea-8e4c-c1f3ab632e18.png">

## Next -- it grabs another image -- why is it cycling through images one of which doesn't exist
https://travis-ci.org/github/earthlab/hub-ops/jobs/701861190#L286

## Then it builds
https://travis-ci.org/github/earthlab/hub-ops/jobs/701861190#L716

but i *don't think it pushes to dockerhub as its not on dockerhub and i never see a push. 

it seems to me that in a PR -- the hub should

1. build the new image fully and push to docker hub if it's successful (i think??) 
2. Then stop before releasing new things to GC  via helm etc.

i may not understand the process but something weird is happening right now with the build. 