### PR TITLE
this will just change the gitpuller location

### DIFF
--- a/hub-charts/edsc-hub/values.yaml
+++ b/hub-charts/edsc-hub/values.yaml
@@ -33,7 +33,7 @@ jupyterhub:
             - "sh"
             - "-c"
             - >
-              gitpuller https://github.com/earthlab/edsc-summer-2020 master edsc-resources;
+              gitpuller https://github.com/earthlab/edsc-summer-2020 master edsc-resources-cln;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool


### PR DESCRIPTION
this should create a new dir for gitpuller files. it should fix the hanging issue we are seeing now.
this addresses #255 .. it's a hack but we need the hub to be accessible this week!!