### PR TITLE
Fix download button & fix staging hub build

### DIFF
--- a/user-images/ea-hub/Dockerfile
+++ b/user-images/ea-hub/Dockerfile
@@ -26,3 +26,7 @@ RUN jupyter nbextension disable --sys-prefix create_assignment/main \
     && jupyter nbextension disable --sys-prefix assignment_list/main --section=tree \
     && jupyter serverextension disable --sys-prefix \
   nbgrader.server_extensions.assignment_list
+
+# Install zip to support the download tool
+USER root
+RUN apt-get update && apt-get -y install zip

--- a/user-images/staginghub/Dockerfile
+++ b/user-images/staginghub/Dockerfile
@@ -30,4 +30,4 @@ RUN jupyter nbextension disable --sys-prefix create_assignment/main \
 # Add the nbgitpuller wrapper script that runs as a postStart lifecycleHook
 # The deploy script copies this file into the right context
 # (see values.yaml in hub-charts)
-COPY wrap_gitpuller.py /tmp/
+# COPY wrap_gitpuller.py /tmp/


### PR DESCRIPTION
this should fix 
1. the download button issue not working - adds zip to the ea hub image
2. removes the python wrapper from gitpuller command on staging hhub which is breaking every build


#272 #276 

ive tested both builds locally and they seem to work!