### PR TITLE
Adding nccasc workshop github usernames to hub

### DIFF
--- a/hub-charts/nccasc-hub/Chart.yaml
+++ b/hub-charts/nccasc-hub/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for the edsc hub
+name: edsc-hub
+version: 0.1.0

--- a/hub-charts/nccasc-hub/requirements.yaml
+++ b/hub-charts/nccasc-hub/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: jupyterhub
+  version: "v0.9.0"
+  repository: "https://jupyterhub.github.io/helm-chart"

--- a/hub-charts/nccasc-hub/values.yaml
+++ b/hub-charts/nccasc-hub/values.yaml
@@ -79,6 +79,13 @@ jupyterhub:
         - shelbyross
         - andpaxt
         - gcgusts
+        - apmonr
+        - ritareisor
+        - pmodi7
+        - carrielevine
+        - caileeny
+        - nvanschmidt
+        - annalopresti
     admin:
       access: true
       users:

--- a/hub-charts/nccasc-hub/values.yaml
+++ b/hub-charts/nccasc-hub/values.yaml
@@ -1,0 +1,94 @@
+jupyterhub:
+  hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+    baseUrl: /nccasc-hub/
+    annotations:
+      prometheus.io/scrape: "true"
+      # this needs to start with the value of `hub.baseUrl`
+      prometheus.io/path: /nccasc-hub/hub/metrics
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+  singleuser:
+    image:
+      # tag will be set by travis on deployment
+      name: earthlabhubops/ea-k8s-user-nccasc-hub
+      tag: set-on-deployment
+    startTimeout: 600
+    cpu:
+      guarantee: 1.
+      limit: 2.
+    memory:
+      guarantee: 1G
+      limit: 2G
+    lifecycleHooks:
+      postStart:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - >
+              gitpuller https://github.com/earthlab/nccasc-climate-data-101;
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+    service:
+      type: ClusterIP
+    chp:
+      resources:
+        requests:
+          cpu: 200m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
+  ingress:
+    enabled: true
+    hosts:
+      - hub.earthdatascience.org
+    annotations:
+      ingress.kubernetes.io/proxy-body-size: 64m
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+    tls:
+      - secretName: kubelego-tls-jupyterhub
+        hosts:
+          - hub.earthdatascience.org
+  auth:
+    whitelist:
+      users:
+        - earth-lab
+        - acrunyon
+        - gretfitz
+        - CQuinn8
+        - shwang01
+        - tbeeton
+        - mhovey8
+        - katherinejchase
+        - sheelbansal
+        - Muellers-CFRI
+        - kaniewskic0106
+        - LizWWA
+        - janewolken
+        - mewieczo
+        - shelbyross
+        - andpaxt
+        - gcgusts
+    admin:
+      access: true
+      users:
+        - lherwehe
+        - nkorinek
+        - lwasser
+    type: github
+    github:
+      callbackUrl: "https://hub.earthdatascience.org/nccasc-hub/hub/oauth_callback"
+  #    org_whitelist:
+  #      - "earthlab-education"
+    scopes:
+      - "read:user"


### PR DESCRIPTION
Hey @lwasser! This is PR adds the github usernames that we have right now for the NCCASC workshop. Only 23 out of 40 RSVPs have added their names to the spreadsheet by the deadline which was 12pm MT today, so I'm thinking we should invite quite a few off the waitlist, which I'll slack you about, so those names will need to be added later.