### PR TITLE
Increase nginx body-size

### DIFF
--- a/hub-configs/ea-hub.yaml
+++ b/hub-configs/ea-hub.yaml
@@ -50,6 +50,7 @@ ingress:
     - hub.earthdatascience.org
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 300m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - secretName: cert-manager-tls

--- a/hub-configs/ea-hub.yaml
+++ b/hub-configs/ea-hub.yaml
@@ -69,7 +69,7 @@ ingress:
     - hub.earthdatascience.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 300m
+    nginx.ingress.kubernetes.io/proxy-body-size: 3000m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - secretName: cert-manager-tls

--- a/hub-configs/nbgrader-hub.yaml
+++ b/hub-configs/nbgrader-hub.yaml
@@ -47,6 +47,7 @@ ingress:
     - hub.earthdatascience.org
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 300m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - secretName: cert-manager-tls

--- a/hub-configs/nbgrader-hub.yaml
+++ b/hub-configs/nbgrader-hub.yaml
@@ -47,7 +47,7 @@ ingress:
     - hub.earthdatascience.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 300m
+    nginx.ingress.kubernetes.io/proxy-body-size: 3000m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - secretName: cert-manager-tls


### PR DESCRIPTION
By default, the nginx ingress has a 1mb limit for upload. We need more to be able to upload data files. 