### PR TITLE
on PRs, build image but do not push

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -1,9 +1,9 @@
-# Builds any changed docker images and pushes to Dockerhub
-# Only runs for PRs; does not re-deploy
+# Builds any changed docker images
+# Only runs for PRs; does not push to Dockerhub or re-deploy
 #
 # The bulk of this workflow happens in the deploy.py script
 
-name: Build, push Docker image
+name: Build Docker image
 
 on:
   pull_request:
@@ -14,7 +14,6 @@ on:
 
 env:
   PYTHON_VERSION: 3.8
-  DOCKERHUB_USERNAME: earthlabcu
   GKE_PROJECT: ea-jupyter
   GKE_ZONE: us-central1-b
   GKE_CLUSTER: jhub2
@@ -22,7 +21,7 @@ env:
 
 jobs:
 
-  build-push:
+  build-image:
     runs-on: ubuntu-latest
 
     strategy:
@@ -38,11 +37,5 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build the Docker image
-        run: python deploy.py --build --push ${{matrix.hubname}}
+        run: python deploy.py --build ${{matrix.hubname}}


### PR DESCRIPTION
This update the GitHub Actions so that on a pull request, we check that the docker image builds, but we do not push to Dockerhub. This means that PR builds do not need access to repository secrets and can be successfully built from forks. 

Addresses #327 