### PR TITLE
reduce timeout failures when starting user pods

### DIFF
--- a/hub-configs/ea-hub.yaml
+++ b/hub-configs/ea-hub.yaml
@@ -18,7 +18,7 @@ singleuser:
     limit: 8G
     guarantee: 4G
   startTimeout: 3600
-  
+
 auth:
   admin:
     access: true
@@ -85,3 +85,5 @@ scheduling:
       matchNodePurpose: require
   userScheduler:
     enabled: true
+  userPlaceholder:
+    replicas: 2

--- a/hub-configs/ea-hub.yaml
+++ b/hub-configs/ea-hub.yaml
@@ -17,7 +17,8 @@ singleuser:
   memory:
     limit: 8G
     guarantee: 4G
-
+  startTimeout: 3600
+  
 auth:
   admin:
     access: true

--- a/hub-configs/nbgrader-hub.yaml
+++ b/hub-configs/nbgrader-hub.yaml
@@ -14,7 +14,7 @@ singleuser:
     guarantee: 4G
     limit: 8G
   startTimeout: 3600
-  
+
 auth:
   admin:
     access: true
@@ -65,3 +65,5 @@ scheduling:
       matchNodePurpose: require
   userScheduler:
     enabled: true
+  userPlaceholder:
+    replicas: 2

--- a/hub-configs/nbgrader-hub.yaml
+++ b/hub-configs/nbgrader-hub.yaml
@@ -13,7 +13,8 @@ singleuser:
   memory:
     guarantee: 4G
     limit: 8G
-
+  startTimeout: 3600
+  
 auth:
   admin:
     access: true


### PR DESCRIPTION
Two changes here:

* increases the length of time before the spawning of a user pod times out
* add [user placeholders](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/optimization.html?highlight=timeout#scaling-up-in-time-user-placeholders) to reduce the time to spawn a new node