### PR TITLE
remove one final instance of nbgrader-hub from actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
     strategy:
       matrix:
-        hubname: [ea-hub, nbgrader-hub]
+        hubname: [ea-hub]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
There was one more instance of nbgrader-hub in the github actions workflow. This PR removes it. 