### PR TITLE
Temporarily removing lifecycle hooks to get around a gitpuller issue.

### DIFF
--- a/hub-charts/ea-hub/values.yaml
+++ b/hub-charts/ea-hub/values.yaml
@@ -32,14 +32,14 @@ jupyterhub:
     memory:
       guarantee: 2G
       limit: 4G
-    lifecycleHooks:
-      postStart:
-        exec:
-          command:
-            - "sh"
-            - "-c"
-            - >
-              gitpuller https://github.com/earthlab-education/ea-bootcamp-fall-2020 master ea-bootcamp-shared;
+    # lifecycleHooks:
+    #   postStart:
+    #     exec:
+    #       command:
+    #         - "sh"
+    #         - "-c"
+    #         - >
+    #           gitpuller https://github.com/earthlab-education/ea-bootcamp-fall-2020 master ea-bootcamp-shared;
   proxy:
     nodeSelector:
       cloud.google.com/gke-nodepool: core-pool


### PR DESCRIPTION
Gitpuller is having issues so pushing up a temporary work around. 